### PR TITLE
Bump version to 1.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
 
 [[package]]
 name = "caesar_cipher_enc_dec"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "clap",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "caesar_cipher_enc_dec"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 description = "can easily use caesar cipher"
 license = "MIT"


### PR DESCRIPTION
## Summary
This release bumps the package version from 1.0.1 to 1.0.2.

## Changes
- Updated version in `Cargo.toml` from 1.0.1 to 1.0.2

## Notes
This appears to be a patch release. No source code changes are included in this update.

https://claude.ai/code/session_0114MmZZEh4hgtuHP6fyoLMF