### PR TITLE
fix: CI エラー修正（clippy・fmt・テストのバージョンハードコード）

### DIFF
--- a/src/caesar_cipher.rs
+++ b/src/caesar_cipher.rs
@@ -77,7 +77,7 @@ impl std::error::Error for CipherError {}
 ///
 /// ```
 /// use caesar_cipher_enc_dec::caesar_cipher::encrypt;
-/// 
+///
 /// let result = encrypt("Hello", 3);
 /// assert_eq!(result, "Khoor");
 /// ```
@@ -103,7 +103,7 @@ pub fn encrypt(text: &str, shift: i16) -> String {
 ///
 /// ```
 /// use caesar_cipher_enc_dec::caesar_cipher::decrypt;
-/// 
+///
 /// let result = decrypt("Khoor", 3);
 /// assert_eq!(result, "Hello");
 /// ```
@@ -134,10 +134,10 @@ pub fn decrypt(text: &str, shift: i16) -> String {
 ///
 /// ```
 /// use caesar_cipher_enc_dec::caesar_cipher::encrypt_safe;
-/// 
+///
 /// let result = encrypt_safe("Hello", 3).unwrap();
 /// assert_eq!(result, "Khoor");
-/// 
+///
 /// // Error cases
 /// assert!(encrypt_safe("", 3).is_err());
 /// assert!(encrypt_safe("Hello", 26).is_err());
@@ -147,7 +147,7 @@ pub fn encrypt_safe(text: &str, shift: i16) -> Result<String, CipherError> {
         return Err(CipherError::EmptyText);
     }
 
-    if shift < -MAX_SHIFT || shift > MAX_SHIFT {
+    if !(-MAX_SHIFT..=MAX_SHIFT).contains(&shift) {
         return Err(CipherError::InvalidShift(format!(
             "Shift value {} is out of range (-{} to {})",
             shift, MAX_SHIFT, MAX_SHIFT
@@ -180,7 +180,7 @@ pub fn encrypt_safe(text: &str, shift: i16) -> Result<String, CipherError> {
 ///
 /// ```
 /// use caesar_cipher_enc_dec::caesar_cipher::decrypt_safe;
-/// 
+///
 /// let result = decrypt_safe("Khoor", 3).unwrap();
 /// assert_eq!(result, "Hello");
 /// ```
@@ -189,7 +189,7 @@ pub fn decrypt_safe(text: &str, shift: i16) -> Result<String, CipherError> {
         return Err(CipherError::EmptyText);
     }
 
-    if shift < -MAX_SHIFT || shift > MAX_SHIFT {
+    if !(-MAX_SHIFT..=MAX_SHIFT).contains(&shift) {
         return Err(CipherError::InvalidShift(format!(
             "Shift value {} is out of range (-{} to {})",
             shift, MAX_SHIFT, MAX_SHIFT
@@ -220,11 +220,13 @@ fn shift_text(text: &str, shift: i16) -> String {
     text.chars()
         .map(|c| match c {
             'A'..='Z' => {
-                let shifted = (c as i16 - UPPERCASE_BASE + normalized_shift).rem_euclid(ALPHABET_SIZE);
+                let shifted =
+                    (c as i16 - UPPERCASE_BASE + normalized_shift).rem_euclid(ALPHABET_SIZE);
                 ((shifted + UPPERCASE_BASE) as u8) as char
             }
             'a'..='z' => {
-                let shifted = (c as i16 - LOWERCASE_BASE + normalized_shift).rem_euclid(ALPHABET_SIZE);
+                let shifted =
+                    (c as i16 - LOWERCASE_BASE + normalized_shift).rem_euclid(ALPHABET_SIZE);
                 ((shifted + LOWERCASE_BASE) as u8) as char
             }
             _ => c,
@@ -305,16 +307,28 @@ mod tests {
 
     #[test]
     fn test_encrypt_safe_invalid_shift() {
-        assert!(matches!(encrypt_safe("Test", 26), Err(CipherError::InvalidShift(_))));
-        assert!(matches!(encrypt_safe("Test", -26), Err(CipherError::InvalidShift(_))));
-        assert!(matches!(encrypt_safe("Test", 100), Err(CipherError::InvalidShift(_))));
+        assert!(matches!(
+            encrypt_safe("Test", 26),
+            Err(CipherError::InvalidShift(_))
+        ));
+        assert!(matches!(
+            encrypt_safe("Test", -26),
+            Err(CipherError::InvalidShift(_))
+        ));
+        assert!(matches!(
+            encrypt_safe("Test", 100),
+            Err(CipherError::InvalidShift(_))
+        ));
     }
 
     #[test]
     fn test_decrypt_safe() {
         assert_eq!(decrypt_safe("Khoor", 3).unwrap(), "Hello");
         assert!(matches!(decrypt_safe("", 3), Err(CipherError::EmptyText)));
-        assert!(matches!(decrypt_safe("Test", 26), Err(CipherError::InvalidShift(_))));
+        assert!(matches!(
+            decrypt_safe("Test", 26),
+            Err(CipherError::InvalidShift(_))
+        ));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use std::env;
 /// or the demonstration mode (when no arguments are provided).
 fn main() {
     let args: Vec<String> = env::args().collect();
-    
+
     if args.len() > 1 {
         if let Err(e) = cli::run_cli() {
             eprintln!("Error: {}", e);
@@ -38,13 +38,13 @@ fn main() {
 fn run_demo() {
     println!("=== Caesar Cipher Demo ===");
     println!("Run with --help to see CLI options\n");
-    
+
     // Basic encryption and decryption
     let text = "I Love You.";
     let enc_text = encrypt(text, 3);
     let dec_text = encrypt(&enc_text, -3);
     let dec_text2 = decrypt(&enc_text, 3);
-    
+
     println!("=== Basic Features ===");
     println!("Original: {}", text);
     println!("Encrypted: {}", enc_text);

--- a/tests/cli_output_tests.rs
+++ b/tests/cli_output_tests.rs
@@ -103,7 +103,15 @@ fn test_cli_encrypt_output_to_file() {
     // When: CLI writes to file
     let result = std::process::Command::new("cargo")
         .args([
-            "run", "--", "encrypt", "--text", "Hello", "--shift", "3", "--output", &output_path_str,
+            "run",
+            "--",
+            "encrypt",
+            "--text",
+            "Hello",
+            "--shift",
+            "3",
+            "--output",
+            &output_path_str,
         ])
         .output()
         .expect("Failed to execute CLI");
@@ -133,7 +141,13 @@ fn test_cli_nonexistent_file_error_contains_path() {
     // When: CLI tries to read from nonexistent file
     let output = std::process::Command::new("cargo")
         .args([
-            "run", "--", "encrypt", "--file", nonexistent_path, "--shift", "3",
+            "run",
+            "--",
+            "encrypt",
+            "--file",
+            nonexistent_path,
+            "--shift",
+            "3",
         ])
         .output()
         .expect("Failed to execute CLI");
@@ -233,10 +247,12 @@ fn test_cli_version_matches_cargo_toml() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
 
-    // Then: Version should match Cargo.toml (1.0.1)
+    // Then: Version should match Cargo.toml (dynamically read at compile time)
+    let expected_version = env!("CARGO_PKG_VERSION");
     assert!(
-        stdout.contains("1.0.1"),
-        "CLI version should be 1.0.1 from Cargo.toml, got: {}",
+        stdout.contains(expected_version),
+        "CLI version should be {} from Cargo.toml, got: {}",
+        expected_version,
         stdout
     );
 }
@@ -245,7 +261,15 @@ fn test_cli_version_matches_cargo_toml() {
 fn test_cli_encrypt_unicode_text() {
     // Given: Unicode text (Japanese + English mix)
     let output = std::process::Command::new("cargo")
-        .args(["run", "--", "encrypt", "--text", "Hello世界", "--shift", "3"])
+        .args([
+            "run",
+            "--",
+            "encrypt",
+            "--text",
+            "Hello世界",
+            "--shift",
+            "3",
+        ])
         .output()
         .expect("Failed to execute CLI");
 

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -20,8 +20,7 @@
 //! | 各定数が正の値           | 異常系防止 | 全定数 > 0                     |
 
 use caesar_cipher_enc_dec::config::{
-    ALPHABET_SIZE, DEFAULT_SHIFT, LOWERCASE_BASE, MAX_BRUTE_FORCE_SHIFT, MAX_SHIFT,
-    UPPERCASE_BASE,
+    ALPHABET_SIZE, DEFAULT_SHIFT, LOWERCASE_BASE, MAX_BRUTE_FORCE_SHIFT, MAX_SHIFT, UPPERCASE_BASE,
 };
 
 // =============================================================================
@@ -136,7 +135,10 @@ fn test_all_constants_are_positive() {
     assert!(MAX_SHIFT > 0, "MAX_SHIFT must be positive");
     assert!(UPPERCASE_BASE > 0, "UPPERCASE_BASE must be positive");
     assert!(LOWERCASE_BASE > 0, "LOWERCASE_BASE must be positive");
-    assert!(MAX_BRUTE_FORCE_SHIFT > 0, "MAX_BRUTE_FORCE_SHIFT must be positive");
+    assert!(
+        MAX_BRUTE_FORCE_SHIFT > 0,
+        "MAX_BRUTE_FORCE_SHIFT must be positive"
+    );
     assert!(DEFAULT_SHIFT > 0, "DEFAULT_SHIFT must be positive");
 }
 
@@ -145,8 +147,14 @@ fn test_base_values_are_valid_ascii() {
     // Given: UPPERCASE_BASE and LOWERCASE_BASE
     // When: Checking if they are valid ASCII letter ranges
     // Then: They should be within valid u8 range and represent letters
-    assert!(UPPERCASE_BASE >= 0 && UPPERCASE_BASE <= 127, "UPPERCASE_BASE must be valid ASCII");
-    assert!(LOWERCASE_BASE >= 0 && LOWERCASE_BASE <= 127, "LOWERCASE_BASE must be valid ASCII");
+    assert!(
+        UPPERCASE_BASE >= 0 && UPPERCASE_BASE <= 127,
+        "UPPERCASE_BASE must be valid ASCII"
+    );
+    assert!(
+        LOWERCASE_BASE >= 0 && LOWERCASE_BASE <= 127,
+        "LOWERCASE_BASE must be valid ASCII"
+    );
     assert_eq!((UPPERCASE_BASE as u8) as char, 'A');
     assert_eq!((LOWERCASE_BASE as u8) as char, 'a');
 }

--- a/tests/decrypt_safe_overflow_tests.rs
+++ b/tests/decrypt_safe_overflow_tests.rs
@@ -20,9 +20,7 @@
 //! | shift=i16::MIN エラーメッセージ | 異常系  | エラーにシフト値が含まれる            |
 //! | 正常値での往復検証             | 正常系   | encrypt_safe→decrypt_safeで復元       |
 
-use caesar_cipher_enc_dec::caesar_cipher::{
-    decrypt_safe, encrypt_safe, CipherError,
-};
+use caesar_cipher_enc_dec::caesar_cipher::{decrypt_safe, encrypt_safe, CipherError};
 
 // =============================================================================
 // Boundary values (境界値)

--- a/tests/roundtrip_tests.rs
+++ b/tests/roundtrip_tests.rs
@@ -2,9 +2,7 @@
 //!
 //! Tests that verify encryption followed by decryption returns the original text.
 
-use caesar_cipher_enc_dec::caesar_cipher::{
-    decrypt, decrypt_safe, encrypt, encrypt_safe,
-};
+use caesar_cipher_enc_dec::caesar_cipher::{decrypt, decrypt_safe, encrypt, encrypt_safe};
 
 // =============================================================================
 // Basic roundtrip tests

--- a/tests/safe_api_tests.rs
+++ b/tests/safe_api_tests.rs
@@ -2,9 +2,7 @@
 //!
 //! Tests for `encrypt_safe` and `decrypt_safe` functions with error handling.
 
-use caesar_cipher_enc_dec::caesar_cipher::{
-    decrypt_safe, encrypt_safe, CipherError,
-};
+use caesar_cipher_enc_dec::caesar_cipher::{decrypt_safe, encrypt_safe, CipherError};
 
 // =============================================================================
 // encrypt_safe function tests


### PR DESCRIPTION
- test_cli_version_matches_cargo_toml のバージョンを env!("CARGO_PKG_VERSION") で動的取得に変更
- clippy: manual_range_contains を !(..).contains() 記法に修正 (encrypt_safe/decrypt_safe)
- cargo fmt: 全ファイルのフォーマット統一

https://claude.ai/code/session_0114MmZZEh4hgtuHP6fyoLMF