### PR TITLE
Refactor release workflow to use artifacts for multi-platform builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,14 +75,30 @@ jobs:
         run: |
           mv target/${{ matrix.job.target }}/release/${{ env.PROJECT_NAME }}${{ matrix.job.extension }} target/${{ matrix.job.target }}/release/${{ env.PROJECT_NAME }}-${{ github.ref_name }}-${{ matrix.job.target }}${{ matrix.job.extension }}
 
-      # ビルド済みバイナリをReleasesに配置
+      # ビルド済みバイナリをアーティファクトとしてアップロード
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.job.target }}
+          path: target/${{ matrix.job.target }}/release/${{ env.PROJECT_NAME }}-${{ github.ref_name }}-${{ matrix.job.target }}${{ matrix.job.extension }}
+
+  # 全ビルドジョブのアーティファクトを集めてReleasesに一括配置
+  release:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
       - name: Release
         uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: |
-            target/${{ matrix.job.target }}/release/${{ env.PROJECT_NAME }}-${{ github.ref_name }}-${{ matrix.job.target }}${{ matrix.job.extension }}
+          files: artifacts/*
 
   # crates.ioへの自動公開
   publish:


### PR DESCRIPTION
## Summary
Refactored the GitHub Actions release workflow to decouple binary building from release creation. The workflow now uploads built binaries as artifacts and uses a separate job to collect and release them, improving workflow efficiency and maintainability.

## Key Changes
- **Build job**: Added artifact upload step to store compiled binaries for each target platform
- **New release job**: Created a separate `release` job that depends on `build` to:
  - Download all artifacts from the build matrix
  - Merge multiple artifacts into a single directory
  - Upload all binaries to GitHub Releases in one step
- **Removed matrix dependency**: The release step no longer depends on the build matrix, simplifying the release logic

## Implementation Details
- Uses `actions/upload-artifact@v4` to store binaries with target platform as the artifact name
- Uses `actions/download-artifact@v4` with `merge-multiple: true` to consolidate all platform binaries
- The `release` job uses `needs: [build]` to ensure all build jobs complete before attempting release
- Simplified the release file pattern from matrix-dependent paths to a simple `artifacts/*` glob

https://claude.ai/code/session_01VLr2RV5gpUYAXjvxWeiCBH