### PR TITLE
Fix integer overflow in decrypt() and align CLI/docs with constants

### DIFF
--- a/src/caesar_cipher.rs
+++ b/src/caesar_cipher.rs
@@ -90,6 +90,10 @@ pub fn encrypt(text: &str, shift: i16) -> String {
 /// This function decrypts the specified text with the given shift value.
 /// Internally uses shift_text with a negative shift value.
 ///
+/// The shift is widened to `i32` before negation to avoid integer overflow
+/// when `shift == i16::MIN`; the normalized value passed to `shift_text` is
+/// always within `0..ALPHABET_SIZE` so no precision is lost.
+///
 /// # Arguments
 ///
 /// * `text` - Text to decrypt
@@ -108,17 +112,20 @@ pub fn encrypt(text: &str, shift: i16) -> String {
 /// assert_eq!(result, "Hello");
 /// ```
 pub fn decrypt(text: &str, shift: i16) -> String {
-    shift_text(text, -shift)
+    let negated = -(shift as i32);
+    let normalized = negated.rem_euclid(ALPHABET_SIZE as i32) as i16;
+    shift_text(text, normalized)
 }
 
 /// Encrypts text using Caesar cipher with error handling
 ///
 /// This function validates input values and returns an error for invalid inputs.
-/// Returns errors for empty text or out-of-range shift values (outside -25 to 25).
+/// Returns errors for empty/whitespace-only text or out-of-range shift values
+/// (outside -25 to 25).
 ///
 /// # Arguments
 ///
-/// * `text` - Text to encrypt (must not be empty)
+/// * `text` - Text to encrypt (must not be empty or whitespace-only)
 /// * `shift` - Shift value (must be in range -25 to 25)
 ///
 /// # Returns
@@ -127,7 +134,7 @@ pub fn decrypt(text: &str, shift: i16) -> String {
 ///
 /// # Errors
 ///
-/// * `CipherError::EmptyText` - When text is empty
+/// * `CipherError::EmptyText` - When text is empty or whitespace-only
 /// * `CipherError::InvalidShift` - When shift value is out of range
 ///
 /// # Examples
@@ -164,7 +171,7 @@ pub fn encrypt_safe(text: &str, shift: i16) -> Result<String, CipherError> {
 ///
 /// # Arguments
 ///
-/// * `text` - Text to decrypt (must not be empty)
+/// * `text` - Text to decrypt (must not be empty or whitespace-only)
 /// * `shift` - Shift value to use for decryption (must be in range -25 to 25)
 ///
 /// # Returns
@@ -173,7 +180,7 @@ pub fn encrypt_safe(text: &str, shift: i16) -> Result<String, CipherError> {
 ///
 /// # Errors
 ///
-/// * `CipherError::EmptyText` - When text is empty
+/// * `CipherError::EmptyText` - When text is empty or whitespace-only
 /// * `CipherError::InvalidShift` - When shift value is out of range
 ///
 /// # Examples

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,7 +30,7 @@ pub struct CipherArgs {
     pub file: Option<String>,
 
     /// Shift value (any integer; safe mode: -25 to 25, default: 3)
-    #[arg(short, long, default_value = "3")]
+    #[arg(short, long, default_value_t = DEFAULT_SHIFT)]
     pub shift: i16,
 
     /// Output file path

--- a/tests/code_review_fixes_tests.rs
+++ b/tests/code_review_fixes_tests.rs
@@ -1,0 +1,246 @@
+//! # Regression Tests for Code Review Fixes
+//!
+//! This file captures regression tests for three improvements:
+//!
+//! 1. `decrypt()` no longer overflows when `shift == i16::MIN`
+//! 2. CLI default shift matches the `DEFAULT_SHIFT` constant (no hardcoded "3")
+//! 3. `encrypt_safe` / `decrypt_safe` docs match behavior for whitespace-only input
+//!
+//! Each test uses the Given / When / Then comment style.
+
+use caesar_cipher_enc_dec::caesar_cipher::{
+    decrypt, decrypt_safe, encrypt, encrypt_safe, CipherError,
+};
+use caesar_cipher_enc_dec::config::{ALPHABET_SIZE, DEFAULT_SHIFT};
+
+// =============================================================================
+// 1. decrypt() integer overflow regression tests
+// =============================================================================
+
+#[test]
+fn test_decrypt_shift_i16_min_does_not_panic() {
+    // Given: shift value equal to i16::MIN (previously caused overflow on -shift)
+    let text = "ABC";
+    let shift = i16::MIN;
+
+    // When: Decrypting
+    let result = decrypt(text, shift);
+
+    // Then: Operation completes without panic and yields a valid rotation
+    //       i16::MIN == -32768. -(-32768) mod 26 == 32768 mod 26 == 8.
+    //       "ABC" shifted by +8 -> "IJK".
+    assert_eq!(result, "IJK");
+}
+
+#[test]
+fn test_decrypt_shift_i16_min_plus_one() {
+    // Given: shift just above the overflow-triggering boundary
+    let text = "ABC";
+    let shift = i16::MIN + 1;
+
+    // When: Decrypting
+    let result = decrypt(text, shift);
+
+    // Then: Matches encrypt with the mathematically equivalent positive shift.
+    //       -(-32767) == 32767; 32767 mod 26 == 7.
+    let expected = encrypt("ABC", 7);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn test_decrypt_shift_i16_max() {
+    // Given: shift at the opposite signed-integer boundary
+    let text = "ABC";
+    let shift = i16::MAX;
+
+    // When: Decrypting
+    let result = decrypt(text, shift);
+
+    // Then: No panic and result equals encrypt with the equivalent positive shift.
+    //       -(32767) mod 26 == (-32767).rem_euclid(26) == 19.
+    let expected = encrypt("ABC", 19);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn test_decrypt_shift_large_negative() {
+    // Given: very negative shift well outside the safe range
+    let text = "Hello";
+    let shift = -30_000;
+
+    // When: Decrypting
+    let result = decrypt(text, shift);
+
+    // Then: decrypt(text, s) == encrypt(text, -s) modulo ALPHABET_SIZE,
+    //       so decrypt with -30000 must equal encrypt with +30000.
+    let expected = encrypt("Hello", 30_000);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn test_decrypt_shift_alphabet_size_equivalence() {
+    // Given: shift equal to ALPHABET_SIZE should be a no-op
+    let text = "Hello World";
+
+    // When: Decrypting with ALPHABET_SIZE
+    let result = decrypt(text, ALPHABET_SIZE);
+
+    // Then: Text unchanged (full rotation)
+    assert_eq!(result, text);
+}
+
+#[test]
+fn test_decrypt_preserves_encrypt_roundtrip_with_extreme_shift() {
+    // Given: encrypt then decrypt with the same large positive shift
+    let original = "Hello World";
+    let shift = 10_000_i16;
+
+    // When: Round-tripping
+    let encrypted = encrypt(original, shift);
+    let decrypted = decrypt(&encrypted, shift);
+
+    // Then: Round-trip yields original text
+    assert_eq!(decrypted, original);
+}
+
+// =============================================================================
+// 2. CLI default shift no longer hardcoded
+// =============================================================================
+
+#[test]
+fn test_cli_default_shift_matches_constant() {
+    // Given: clap is configured with `default_value_t = DEFAULT_SHIFT`
+    use clap::Parser;
+    use caesar_cipher_enc_dec::cli::{Cli, Commands};
+
+    // When: Parsing a command that does not specify --shift
+    let cli = Cli::try_parse_from(["caesar_cipher", "encrypt", "--text", "Hello"])
+        .expect("parse should succeed");
+
+    // Then: Default value equals DEFAULT_SHIFT constant
+    match cli.command {
+        Commands::Encrypt(args) => assert_eq!(args.shift, DEFAULT_SHIFT),
+        _ => panic!("expected Encrypt subcommand"),
+    }
+}
+
+#[test]
+fn test_cli_default_shift_applies_to_decrypt() {
+    // Given: decrypt subcommand without explicit shift
+    use clap::Parser;
+    use caesar_cipher_enc_dec::cli::{Cli, Commands};
+
+    // When: Parsing
+    let cli = Cli::try_parse_from(["caesar_cipher", "decrypt", "--text", "Khoor"])
+        .expect("parse should succeed");
+
+    // Then: Default still follows constant, not a hardcoded literal
+    match cli.command {
+        Commands::Decrypt(args) => assert_eq!(args.shift, DEFAULT_SHIFT),
+        _ => panic!("expected Decrypt subcommand"),
+    }
+}
+
+#[test]
+fn test_cli_explicit_shift_overrides_default() {
+    // Given: explicit --shift on the command line
+    use clap::Parser;
+    use caesar_cipher_enc_dec::cli::{Cli, Commands};
+
+    // When: Parsing
+    let cli =
+        Cli::try_parse_from(["caesar_cipher", "encrypt", "--text", "Hi", "--shift", "7"])
+            .expect("parse should succeed");
+
+    // Then: Explicit value is used, not the default
+    match cli.command {
+        Commands::Encrypt(args) => assert_eq!(args.shift, 7),
+        _ => panic!("expected Encrypt subcommand"),
+    }
+}
+
+// =============================================================================
+// 3. Docstring / behavior alignment: whitespace-only text is rejected
+// =============================================================================
+
+#[test]
+fn test_encrypt_safe_rejects_empty_string() {
+    // Given: empty string input
+    let text = "";
+
+    // When: Calling encrypt_safe
+    let result = encrypt_safe(text, 3);
+
+    // Then: Returns EmptyText error
+    assert!(matches!(result, Err(CipherError::EmptyText)));
+}
+
+#[test]
+fn test_encrypt_safe_rejects_spaces_only() {
+    // Given: whitespace-only (spaces) input
+    let text = "     ";
+
+    // When: Calling encrypt_safe
+    let result = encrypt_safe(text, 3);
+
+    // Then: Rejected as EmptyText per documented behavior
+    assert!(matches!(result, Err(CipherError::EmptyText)));
+}
+
+#[test]
+fn test_encrypt_safe_rejects_tabs_and_newlines() {
+    // Given: whitespace-only (tabs and newlines) input
+    let text = "\t\n\r  ";
+
+    // When: Calling encrypt_safe
+    let result = encrypt_safe(text, 3);
+
+    // Then: Rejected as EmptyText
+    assert!(matches!(result, Err(CipherError::EmptyText)));
+}
+
+#[test]
+fn test_decrypt_safe_rejects_whitespace_only() {
+    // Given: whitespace-only input to decrypt_safe
+    let text = "   \t";
+
+    // When: Calling decrypt_safe
+    let result = decrypt_safe(text, 3);
+
+    // Then: Rejected consistently with encrypt_safe
+    assert!(matches!(result, Err(CipherError::EmptyText)));
+}
+
+#[test]
+fn test_encrypt_safe_accepts_text_with_surrounding_whitespace() {
+    // Given: valid text surrounded by whitespace (not whitespace-only)
+    let text = "  Hi  ";
+
+    // When: Calling encrypt_safe
+    let result = encrypt_safe(text, 3);
+
+    // Then: Succeeds and whitespace is preserved in output
+    let encrypted = result.expect("non-empty text should succeed");
+    assert_eq!(encrypted, "  Kl  ");
+}
+
+#[test]
+fn test_empty_text_error_message_mentions_whitespace() {
+    // Given: the CipherError::EmptyText variant
+    let err = CipherError::EmptyText;
+
+    // When: Formatting as a string
+    let msg = format!("{}", err);
+
+    // Then: Message explicitly mentions whitespace-only rejection so user-facing
+    //       messages match documentation
+    assert!(
+        msg.contains("whitespace"),
+        "expected message to mention whitespace, got: {}",
+        msg
+    );
+}
+
+// Execution & coverage:
+//   cargo test --test code_review_fixes_tests
+//   cargo tarpaulin --tests   (for branch/line coverage, if tarpaulin is installed)

--- a/tests/code_review_fixes_tests.rs
+++ b/tests/code_review_fixes_tests.rs
@@ -110,8 +110,8 @@ fn test_decrypt_preserves_encrypt_roundtrip_with_extreme_shift() {
 #[test]
 fn test_cli_default_shift_matches_constant() {
     // Given: clap is configured with `default_value_t = DEFAULT_SHIFT`
-    use clap::Parser;
     use caesar_cipher_enc_dec::cli::{Cli, Commands};
+    use clap::Parser;
 
     // When: Parsing a command that does not specify --shift
     let cli = Cli::try_parse_from(["caesar_cipher", "encrypt", "--text", "Hello"])
@@ -127,8 +127,8 @@ fn test_cli_default_shift_matches_constant() {
 #[test]
 fn test_cli_default_shift_applies_to_decrypt() {
     // Given: decrypt subcommand without explicit shift
-    use clap::Parser;
     use caesar_cipher_enc_dec::cli::{Cli, Commands};
+    use clap::Parser;
 
     // When: Parsing
     let cli = Cli::try_parse_from(["caesar_cipher", "decrypt", "--text", "Khoor"])
@@ -144,13 +144,12 @@ fn test_cli_default_shift_applies_to_decrypt() {
 #[test]
 fn test_cli_explicit_shift_overrides_default() {
     // Given: explicit --shift on the command line
-    use clap::Parser;
     use caesar_cipher_enc_dec::cli::{Cli, Commands};
+    use clap::Parser;
 
     // When: Parsing
-    let cli =
-        Cli::try_parse_from(["caesar_cipher", "encrypt", "--text", "Hi", "--shift", "7"])
-            .expect("parse should succeed");
+    let cli = Cli::try_parse_from(["caesar_cipher", "encrypt", "--text", "Hi", "--shift", "7"])
+        .expect("parse should succeed");
 
     // Then: Explicit value is used, not the default
     match cli.command {


### PR DESCRIPTION
## Summary

This PR addresses three code review findings:

1. **Integer overflow in `decrypt()`**: The function now safely handles `shift == i16::MIN` by widening to `i32` before negation
2. **CLI default shift**: Replaced hardcoded `"3"` with `DEFAULT_SHIFT` constant reference
3. **Documentation alignment**: Updated docstrings to accurately reflect that whitespace-only input is rejected as `EmptyText`

## Key Changes

- **`src/caesar_cipher.rs`**:
  - Modified `decrypt()` to widen shift to `i32` before negation, preventing overflow when `shift == i16::MIN`
  - Normalized the result using `rem_euclid()` to ensure the value stays within `0..ALPHABET_SIZE`
  - Updated docstrings for `encrypt_safe()` and `decrypt_safe()` to document that whitespace-only text is rejected
  - Added implementation note explaining the overflow prevention technique

- **`src/cli.rs`**:
  - Changed `#[arg(short, long, default_value = "3")]` to `#[arg(short, long, default_value_t = DEFAULT_SHIFT)]`
  - Ensures CLI default is derived from the constant, eliminating hardcoded magic numbers

- **`tests/code_review_fixes_tests.rs`** (new file):
  - Added 15 comprehensive regression tests covering all three fixes
  - Tests use Given/When/Then comment style for clarity
  - Validates edge cases: `i16::MIN`, `i16::MAX`, large negative shifts, and whitespace-only input handling

## Implementation Details

The `decrypt()` fix uses Euclidean remainder to safely normalize the negated shift:
```rust
let negated = -(shift as i32);  // Safe: i32 can hold -i16::MIN
let normalized = negated.rem_euclid(ALPHABET_SIZE as i32) as i16;
```

This ensures the final value is always in `0..26`, matching the behavior of the original implementation for all valid inputs while preventing panics on boundary values.

https://claude.ai/code/session_012FR4YMg4EWGZ8Nom1p3Sd4