### PR TITLE
docs: READMEのインストール依存バージョンを1.0.4に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-caesar_cipher_enc_dec = "0.6.2"
+caesar_cipher_enc_dec = "1.0.4"
 ```
+
+> Note: This version is pinned for documentation consistency with this repository (`Cargo.toml`). For the latest release, always check [crates.io](https://crates.io/crates/caesar_cipher_enc_dec).
 
 ## Library Usage
 


### PR DESCRIPTION
### Motivation
- `README.md` の Installation セクションの依存バージョンが `Cargo.toml` の `version = "1.0.4"` と不一致だったため、ドキュメントとメタデータを整合させ、今後の更新漏れを防ぐために README に最新版は `crates.io` を参照する旨の注記を追加しました。

### Description
- `README.md` を修正し、`[dependencies] caesar_cipher_enc_dec = "0.6.2"` を `"1.0.4"` に更新するとともに、該当ブロックの下に「この記載はリポジトリの `Cargo.toml` と整合させた固定版であり、最新は `crates.io` を参照する」注記を追記しました（変更ファイル: `README.md`）。

### Testing
- 自動テストを `cargo test` で実行し、全テストが成功すること（すべてのテストが `ok`）を確認しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e20c80ba388324b3648322d9c7d114)