### PR TITLE
stdin入力で末尾改行のみを除去し先頭/末尾スペースを保持する修正

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -179,9 +179,13 @@ fn get_input_text(
                 )
                 .into());
             }
-            Ok(input.trim().to_string())
+            Ok(trim_trailing_newline(&input).to_string())
         }
     }
+}
+
+fn trim_trailing_newline(input: &str) -> &str {
+    input.trim_end_matches(['\n', '\r'])
 }
 
 /// Outputs the result to either a file or stdout
@@ -394,6 +398,13 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("Cannot specify both text and file"));
+    }
+
+    #[test]
+    fn test_trim_trailing_newline_preserves_leading_and_trailing_spaces() {
+        let input = "  keep spaces  \n";
+        let result = trim_trailing_newline(input);
+        assert_eq!(result, "  keep spaces  ");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- `get_input_text` の stdin 分岐で `read_line` による末尾改行のみを除去し、ユーザが入力した先頭/末尾の空白を保持するための修正。\n
### Description
- `get_input_text` の `(None, None)` ブランチで `input.trim()` をやめ、`trim_trailing_newline(&input).to_string()` を返すように変更しました。\n
- 末尾改行のみを除去するヘルパー `trim_trailing_newline` を追加し、内部で `trim_end_matches(['\n', '\r'])` を使用するように実装しました。\n
- 先頭・末尾スペースが保持されることを確認するユニットテスト `test_trim_trailing_newline_preserves_leading_and_trailing_spaces` を `src/cli.rs` の `tests` モジュールに追加しました。\n
### Testing
- `cargo test test_trim_trailing_newline_preserves_leading_and_trailing_spaces -- --nocapture` を実行し、追加したテストは成功しました。\n
- プロジェクトのテスト実行は問題なく終了し、既存のユニットテストに影響がないことを確認しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e20c8237048324bfea920474022fb1)