### PR TITLE
refactor: decrypt_safeで復号処理をdecryptへ集約

### DIFF
--- a/src/caesar_cipher.rs
+++ b/src/caesar_cipher.rs
@@ -167,7 +167,8 @@ pub fn encrypt_safe(text: &str, shift: i16) -> Result<String, CipherError> {
 /// Decrypts text using Caesar cipher with error handling
 ///
 /// This function validates input values and returns an error for invalid inputs.
-/// Validates shift range before negation to prevent integer overflow.
+/// Internally uses `decrypt` after validation, so fixes in `decrypt`
+/// are automatically reflected in this safe API.
 ///
 /// # Arguments
 ///
@@ -203,7 +204,7 @@ pub fn decrypt_safe(text: &str, shift: i16) -> Result<String, CipherError> {
         )));
     }
 
-    Ok(shift_text(text, -shift))
+    Ok(decrypt(text, shift))
 }
 
 /// Internal implementation: Performs text-level Caesar cipher transformation


### PR DESCRIPTION
### Motivation
- `decrypt_safe` が復号処理を個別に行っており、`decrypt` 側の修正が自動反映されない懸念があるため、復号ロジックを一箇所に集約する目的です。

### Description
- `decrypt_safe` の入力検証後の処理を `Ok(decrypt(text, shift))` に置き換え、docコメントに「内部的に `decrypt` を利用する」旨を追記しました。 

### Testing
- `cargo test` を実行し、ユニットテスト／統合テスト／ドキュメントテストを含む全自動テストが成功しました（全テスト通過）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e20c836b9483248bce5b9ec21a5fd6)