### PR TITLE
fix: crates.io公開ワークフローを冪等化

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,33 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Extract crate metadata
+        id: crate_metadata
+        shell: bash
+        run: |
+          CRATE_NAME=$(cargo metadata --no-deps --format-version 1 | python3 -c "import json, sys; print(json.load(sys.stdin)['packages'][0]['name'])")
+          CRATE_VERSION=$(cargo metadata --no-deps --format-version 1 | python3 -c "import json, sys; print(json.load(sys.stdin)['packages'][0]['version'])")
+          echo "crate_name=${CRATE_NAME}" >> "${GITHUB_OUTPUT}"
+          echo "crate_version=${CRATE_VERSION}" >> "${GITHUB_OUTPUT}"
+
+      - name: Check if version is already published
+        id: publish_guard
+        shell: bash
+        run: |
+          set -euo pipefail
+          PUBLISH_STATUS=$(curl --silent --output /dev/null --write-out "%{http_code}" "https://crates.io/api/v1/crates/${{ steps.crate_metadata.outputs.crate_name }}/${{ steps.crate_metadata.outputs.crate_version }}")
+          if [ "${PUBLISH_STATUS}" = "200" ]; then
+            echo "should_publish=false" >> "${GITHUB_OUTPUT}"
+            echo "Version ${{ steps.crate_metadata.outputs.crate_version }} is already published for ${{ steps.crate_metadata.outputs.crate_name }}. Skipping publish."
+          elif [ "${PUBLISH_STATUS}" = "404" ]; then
+            echo "should_publish=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "Unexpected status from crates.io API: ${PUBLISH_STATUS}"
+            exit 1
+          fi
+
       - name: Publish to crates.io
+        if: ${{ steps.publish_guard.outputs.should_publish == 'true' }}
         run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -154,7 +154,8 @@ fn get_input_text(
     }
 
     if let Some(f) = file {
-        let metadata = fs::metadata(&f).map_err(|e| format!("Failed to read file '{}': {}", f, e))?;
+        let metadata =
+            fs::metadata(&f).map_err(|e| format!("Failed to read file '{}': {}", f, e))?;
         if metadata.len() > MAX_INPUT_SIZE as u64 {
             return Err(format!(
                 "Input file '{}' exceeds maximum size of {} bytes",
@@ -162,7 +163,8 @@ fn get_input_text(
             )
             .into());
         }
-        return fs::read_to_string(&f).map_err(|e| format!("Failed to read file '{}': {}", f, e).into());
+        return fs::read_to_string(&f)
+            .map_err(|e| format!("Failed to read file '{}': {}", f, e).into());
     }
 
     print!("Enter text: ");
@@ -179,6 +181,7 @@ fn get_input_text(
     Ok(input.trim().to_string())
 }
 
+#[cfg(test)]
 fn trim_trailing_newline(input: &str) -> &str {
     input.trim_end_matches(['\n', '\r'])
 }

--- a/tests/cli_output_tests.rs
+++ b/tests/cli_output_tests.rs
@@ -181,7 +181,10 @@ fn test_cli_both_text_and_file_error() {
     let stderr = String::from_utf8_lossy(&output.stderr);
 
     // Then: clap validates conflict before application logic
-    assert!(!output.status.success(), "Command should fail on clap validation");
+    assert!(
+        !output.status.success(),
+        "Command should fail on clap validation"
+    );
     assert!(
         stderr.contains("cannot be used with") || stderr.contains("conflicts with"),
         "Error should mention clap conflict, got: {}",
@@ -213,7 +216,10 @@ fn test_cli_brute_force_both_text_and_file_error() {
     let stderr = String::from_utf8_lossy(&output.stderr);
 
     // Then: clap validates conflict before application logic
-    assert!(!output.status.success(), "Command should fail on clap validation");
+    assert!(
+        !output.status.success(),
+        "Command should fail on clap validation"
+    );
     assert!(
         stderr.contains("cannot be used with") || stderr.contains("conflicts with"),
         "Error should mention clap conflict, got: {}",


### PR DESCRIPTION
### Motivation
- 同一タグでワークフローを再実行した際や既に公開済みのバージョンに対して `cargo publish` を実行するとジョブが失敗する問題を防止するための変更です。
- crate 名やバージョンをハードコードせず自動取得して公開判定を行うことで運用の頑健性を高めます。

### Description
- `publish` ジョブに `Extract crate metadata` ステップを追加し、`cargo metadata` と簡易 Python パーサで `crate_name` と `crate_version` を取得して `GITHUB_OUTPUT` に出力するようにしました。 
- `Check if version is already published` ステップを追加し、`curl` で `https://crates.io/api/v1/crates/{name}/{version}` を叩いて `200` はスキップ、`404` は公開対象、その他はエラーとして失敗させるようにしました。 
- `Publish to crates.io` ステップに条件分岐 `if: ${{ steps.publish_guard.outputs.should_publish == 'true' }}` を追加して、未公開時のみ `cargo publish` を実行するようにしました。

### Testing
- 既存のテストスイートをローカルで `cargo test --verbose` により実行し、全ての自動テストが成功することを確認しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2497f23408324b628388b2b03b055)