### PR TITLE
fix: stdin入力で前後スペースが消える不具合を修正

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -178,10 +178,10 @@ fn get_input_text(
         )
         .into());
     }
-    Ok(input.trim().to_string())
+    Ok(trim_trailing_newline(&input).to_string())
 }
 
-#[cfg(test)]
+/// Strips only trailing line endings from stdin/file-style input, preserving spaces.
 fn trim_trailing_newline(input: &str) -> &str {
     input.trim_end_matches(['\n', '\r'])
 }
@@ -227,13 +227,13 @@ fn output_result(
 ///
 /// # Returns
 ///
-/// The trimmed input string
+/// Input with trailing line endings removed (leading/trailing spaces preserved).
 fn prompt_for_text(prompt: &str) -> io::Result<String> {
     print!("{}", prompt);
     io::stdout().flush()?;
     let mut input = String::new();
     io::stdin().read_line(&mut input)?;
-    Ok(input.trim().to_string())
+    Ok(trim_trailing_newline(&input).to_string())
 }
 
 /// Validates shift input string and returns parsed value with optional warning

--- a/tests/cli_output_tests.rs
+++ b/tests/cli_output_tests.rs
@@ -58,7 +58,15 @@ fn test_cli_encrypt_stdin_matches_text_arg_for_surrounding_spaces() {
 
     // Given: --text with surrounding spaces
     let text_arg_output = Command::new("cargo")
-        .args(["run", "--", "encrypt", "--text", "  Hello  ", "--shift", "3"])
+        .args([
+            "run",
+            "--",
+            "encrypt",
+            "--text",
+            "  Hello  ",
+            "--shift",
+            "3",
+        ])
         .output()
         .expect("Failed to execute CLI with --text");
     assert!(text_arg_output.status.success());

--- a/tests/cli_output_tests.rs
+++ b/tests/cli_output_tests.rs
@@ -52,6 +52,55 @@ fn test_cli_encrypt_with_text_arg() {
 }
 
 #[test]
+fn test_cli_encrypt_stdin_matches_text_arg_for_surrounding_spaces() {
+    use std::io::Write;
+    use std::process::{Command, Stdio};
+
+    // Given: --text with surrounding spaces
+    let text_arg_output = Command::new("cargo")
+        .args(["run", "--", "encrypt", "--text", "  Hello  ", "--shift", "3"])
+        .output()
+        .expect("Failed to execute CLI with --text");
+    assert!(text_arg_output.status.success());
+    let text_arg_line = String::from_utf8_lossy(&text_arg_output.stdout)
+        .lines()
+        .last()
+        .unwrap_or("")
+        .to_string();
+
+    // When: the same text is provided via stdin
+    let mut stdin_child = Command::new("cargo")
+        .args(["run", "--", "encrypt", "--shift", "3"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn CLI for stdin");
+    stdin_child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(b"  Hello  \n")
+        .unwrap();
+    let stdin_output = stdin_child.wait_with_output().unwrap();
+    assert!(stdin_output.status.success());
+    let stdin_stdout = String::from_utf8_lossy(&stdin_output.stdout);
+    let stdin_line = stdin_stdout
+        .strip_prefix("Enter text: ")
+        .unwrap_or(&stdin_stdout)
+        .trim_end_matches(['\n', '\r'])
+        .to_string();
+
+    // Then: ciphertext matches and surrounding spaces are preserved
+    assert_eq!(
+        text_arg_line, stdin_line,
+        "--text line: {:?}, stdin ciphertext: {:?}, full stdin stdout: {:?}",
+        text_arg_line, stdin_line, stdin_stdout
+    );
+    assert_eq!(stdin_line, "  Khoor  ");
+}
+
+#[test]
 fn test_cli_decrypt_with_text_arg() {
     // Given: CLI with decrypt command and text argument
     let output = std::process::Command::new("cargo")


### PR DESCRIPTION
## 概要

CLI の `encrypt` / `decrypt` で、**stdin 入力**と **`--text` 引数**の暗号化結果が一致しない不具合を修正しました。

## 原因

`get_input_text` の stdin 経路および対話モードの `prompt_for_text` が `input.trim()` により**前後の空白まで除去**していました。一方 `--text` はそのまま渡すため、同じ文字列でも結果が異なっていました。

| 入力 | 修正前 | 修正後 |
|------|--------|--------|
| `--text "  Hello  "` | `  Khoor  ` | `  Khoor  ` |
| stdin `  Hello  ` + Enter | `Khoor` | `  Khoor  ` |

`trim_trailing_newline` はテスト用（`#[cfg(test)]`）に閉じ込められており、本番の stdin では使われていませんでした（過去 PR #14 で一度修正された経緯がありますが、リファクタ後に `trim()` に戻っていました）。

## 変更内容

- `get_input_text` / `prompt_for_text`: `trim()` → `trim_trailing_newline`（末尾 `\n` / `\r` のみ除去、スペースは保持）
- `trim_trailing_newline` を本番コードでも利用可能に変更
- 回帰防止: stdin と `--text` の出力が一致することを検証する統合テストを追加

## テスト計画

- [x] `cargo test`（全テスト）
- [x] `cargo test test_cli_encrypt_stdin_matches_text_arg_for_surrounding_spaces --test cli_output_tests`
- [x] 手動確認: `printf '  Hello  \n' | cargo run -- encrypt --shift 3` と `cargo run -- encrypt --text "  Hello  " --shift 3` の出力が一致すること

## 補足（スコープ外）

- **ファイル入力**は末尾改行を含めてそのまま読み込むため、stdin とは末尾改行の扱いが異なる場合があります（従来どおり）。
- **`--safe` なし**では空白のみの入力はエラーにしません（safe API の仕様差）。


Made with [Cursor](https://cursor.com)
