### PR TITLE
chore: Cursor / エージェント設定をローカル専用として ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 target
 .DS_Store
+
+# Cursor / エージェント（ローカルのみ）
+.cursor/
+AGENTS.md


### PR DESCRIPTION
## Summary

- `.gitignore` に `.cursor/` と `AGENTS.md` を追加し、Cursor 用のルール・エージェント設定をリポジトリの追跡対象外にした
- リポジトリ本体は Rust プロジェクトのコードのみを共有し、IDE / エージェント設定は各開発者のローカルで管理する方針

## Test plan

- [ ] `git status` で `.cursor/` と `AGENTS.md` が untracked として表示されないこと
- [ ] 既存の `cargo test` / CI に影響がないこと（`.gitignore` のみの変更）


Made with [Cursor](https://cursor.com)