### PR TITLE
chore: bump crate version to 1.0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
 
 [[package]]
 name = "caesar_cipher_enc_dec"
-version = "1.0.4"
+version = "1.0.9"
 dependencies = [
  "clap",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "caesar_cipher_enc_dec"
-version = "1.0.4"
+version = "1.0.9"
 edition = "2021"
 description = "can easily use caesar cipher"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-caesar_cipher_enc_dec = "1.0.4"
+caesar_cipher_enc_dec = "1.0.9"
 ```
 
 > Note: This version is pinned for documentation consistency with this repository (`Cargo.toml`). For the latest release, always check [crates.io](https://crates.io/crates/caesar_cipher_enc_dec).


### PR DESCRIPTION
## Summary

- `Cargo.toml` のクレート版を `1.0.9` に更新
- `Cargo.lock` を同期
- `README.md` の依存関係例を `1.0.9` に更新

Git タグ `v1.0.9` と Crates.io 公開のため、タグ名と `Cargo.toml` の `version` を一致させる変更です。

## Test plan

- [x] `cargo test`（ローカルで 60 件成功）
- [ ] マージ後: `git tag v1.0.9 && git push origin v1.0.9` で Release ワークフローを起動
- [ ] Crates.io に `1.0.9` が公開されることを確認

> **Note:** `release.yml` の Crates.io API 事前チェックが User-Agent なし `curl` で 403 になる問題は別途修正が必要な場合があります。`publish` ジョブが失敗する場合はその対応を検討してください。


Made with [Cursor](https://cursor.com)