### PR TITLE
chore: bump version to 1.0.10 for crates.io publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
 
 [[package]]
 name = "caesar_cipher_enc_dec"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "clap",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "caesar_cipher_enc_dec"
-version = "1.0.9"
+version = "1.0.10"
 edition = "2021"
 description = "can easily use caesar cipher"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-caesar_cipher_enc_dec = "1.0.9"
+caesar_cipher_enc_dec = "1.0.10"
 ```
 
 > Note: This version is pinned for documentation consistency with this repository (`Cargo.toml`). For the latest release, always check [crates.io](https://crates.io/crates/caesar_cipher_enc_dec).


### PR DESCRIPTION
## Summary
- Bump `Cargo.toml` / `Cargo.lock` / README dependency pin to **1.0.10**
- Enables Release workflow `publish` job (User-Agent fix on main) to publish a new crate version to Crates.io

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`
- [ ] After merge: push tag `v1.0.10` and verify Release workflow `publish` succeeds


Made with [Cursor](https://cursor.com)